### PR TITLE
Fix Custom Mouse Cursors and their Scaling

### DIFF
--- a/org.upscayl.Upscayl.yml
+++ b/org.upscayl.Upscayl.yml
@@ -14,7 +14,9 @@ finish-args:
   - --share=network
   - --socket=wayland
   - --socket=fallback-x11
-  - --socket=pulseaudio
+  - --socket=pulseaudio  
+  # Ensure that custom mouse cursors are used and scale properly
+  - --env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons
 
 modules:
   - name: zypak

--- a/org.upscayl.Upscayl.yml
+++ b/org.upscayl.Upscayl.yml
@@ -14,7 +14,7 @@ finish-args:
   - --share=network
   - --socket=wayland
   - --socket=fallback-x11
-  - --socket=pulseaudio  
+  - --socket=pulseaudio
   # Ensure that custom mouse cursors are used and scale properly
   - --env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons
 


### PR DESCRIPTION
This is a common fix among Flatpak packages to ensure that custom mouse cursor themes are picked up and used with their correct scaling.

Fixes https://github.com/upscayl/upscayl/issues/965