### PR TITLE
Add `.gitignore` File

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build/
+.flatpak-builder/


### PR DESCRIPTION
Pretty self-explanatory, eases maintenance as these are the most commonly used directories for building the Flatpak.