### PR TITLE
Remove Unused Dependency

### DIFF
--- a/org.upscayl.Upscayl.yml
+++ b/org.upscayl.Upscayl.yml
@@ -19,15 +19,6 @@ finish-args:
   - --env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons
 
 modules:
-  - name: zypak
-    sources:
-      - type: git
-        url: https://github.com/refi64/zypak
-        tag: v2024.01.17
-        commit: ded79a2f8a509adc21834b95a9892073d4a91fdc
-        x-checker-data:
-          type: git
-          tag-pattern: ^v([\d.]+)$
   - name: upscayl
     buildsystem: simple
     sources:


### PR DESCRIPTION
I just realized that there isn't even really a reason for `zypak` to be included in the manifest like that, as it comes bundled with `org.electronjs.Electron2.BaseApp`. I'm not sure why exactly this was added in the first place and if I'm missing something obvious, please let me know, but that's how usually Electron Flatpak packages are packaged.

Closes: #42 also I guess